### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && apt-get -y install curl software-properties-common \
     && add-apt-repository -y ppa:brightbox/ruby-ng \
     && apt-get update \
-    && apt-get install -y ruby2.4 ruby2.4-dev supervisor redis-server \
+    && apt-get install -y ruby2.6 ruby2.6-dev supervisor redis-server \
         zlib1g-dev libxml2-dev libxslt1-dev libsqlite3-dev postgresql \
         postgresql-contrib libpq-dev libxmlsec1-dev curl make g++ git \
         unzip fontforge libicu-dev


### PR DESCRIPTION
- Ruby version of canvas master branch uses version 2.6 this Dockerfile installs ruby version 2.4 causing a build error, fixed the issue.